### PR TITLE
Twitter share 機能

### DIFF
--- a/src/components/GameEndDisplay.vue
+++ b/src/components/GameEndDisplay.vue
@@ -47,6 +47,8 @@
         </b-container>
         <br>
         <b-button variant="primary" @click="gameStart">Retry</b-button>
+        <br>
+        <a :href="twitter_url">test</a>
     </div>
 </template>
 
@@ -67,6 +69,9 @@
       },
       missTypeCount() {
         return this.$store.state.missCount
+      },
+      twitter_url(){
+        return this.$store.state.twitter_share
       },
       accuracy() {
         if (this.totalTypeCount === 0) {

--- a/src/components/GameEndDisplay.vue
+++ b/src/components/GameEndDisplay.vue
@@ -48,7 +48,7 @@
         <br>
         <b-button variant="primary" @click="gameStart">Retry</b-button>
         <br>
-        <a :href="twitter_url">test</a>
+        <a :href="twitter_url">Twitter</a>
     </div>
 </template>
 
@@ -71,7 +71,8 @@
         return this.$store.state.missCount
       },
       twitter_url(){
-        return this.$store.state.twitter_share
+        this.$store.commit("twitter_url_create")
+        return this.$store.state.twitter_share_url
       },
       accuracy() {
         if (this.totalTypeCount === 0) {

--- a/src/store.js
+++ b/src/store.js
@@ -20,7 +20,7 @@ export default new Vuex.Store({
     isGameClear: false,
     type_count: 0,
     type_size: 100,
-    twitter_share: "https://twitter.com/intent/tweet"
+    twitter_share_url: "https://twitter.com/intent/tweet?"
   },
   mutations: {
     initMondai(state, init_param) {
@@ -92,6 +92,19 @@ export default new Vuex.Store({
     },
     decrementInterval(state, decrement) {
       state.interval -= decrement
+    },
+    twitter_url_create(state){
+      //ここを変更することで，twitterのシェアの最初に表示するやつを変える
+      let count = state.missCount + state.typeSuccessCount
+      let text = "=== N-Typing 結果 ===\n"
+      text += "クリアステージ数:" + state.successStage + "\n"
+      text += "タイプ回数:" + count + "\n"
+      text += "タイプ成功数:" + state.typeSuccessCount + "\n"
+      text += "タイプ成功率:" + Math.ceil((state.typeSuccessCount / count) * 100) + "\%\n"
+      text += "サイトURL:" + "dummy\n"
+      text += "すごい!!!"
+      text += "#N_Typing #SCLA"
+      state.twitter_share_url = state.twitter_share_url + "text=" + encodeURIComponent(text);
     }
   }
 })

--- a/src/store.js
+++ b/src/store.js
@@ -19,7 +19,8 @@ export default new Vuex.Store({
     onEnter: 0,
     isGameClear: false,
     type_count: 0,
-    type_size: 100
+    type_size: 100,
+    twitter_share: "https://twitter.com/intent/tweet"
   },
   mutations: {
     initMondai(state, init_param) {


### PR DESCRIPTION
最後のページのretryの下にTwitterリンクを追加
Twitterの投稿ページに飛んで

=== N-Typing 結果 ===
クリアステージ数: x
タイプ回数: xxx
タイプ成功数: xxx
タイプ成功率: xx %
サイトURL: dummy
すごい!!!
#N_Typing #SCLA

と入力されたツイートを表示する